### PR TITLE
Change the return value

### DIFF
--- a/Runtime/SentrySdk.cs
+++ b/Runtime/SentrySdk.cs
@@ -74,27 +74,27 @@ public class SentrySdk : MonoBehaviour
         _instance.DoAddBreadcrumb(message);
     }
 
-    public static void CaptureMessage(string message)
+    public static Coroutine CaptureMessage(string message)
     {
         if (_instance == null)
         {
-            return;
+            return null;
         }
 
-        _instance.DoCaptureMessage(message);
+        return _instance.DoCaptureMessage(message);
     }
 
-    public static void CaptureEvent(SentryEvent @event)
+    public static Coroutine CaptureEvent(SentryEvent @event)
     {
         if (_instance == null)
         {
-            return;
+            return null;
         }
 
-        _instance.DoCaptureEvent(@event);
+        return _instance.DoCaptureEvent(@event);
     }
 
-    private void DoCaptureMessage(string message)
+    private Coroutine DoCaptureMessage(string message)
     {
         if (Debug)
         {
@@ -106,17 +106,17 @@ public class SentrySdk : MonoBehaviour
             level = "info"
         };
 
-        DoCaptureEvent(@event);
+        return DoCaptureEvent(@event);
     }
 
-    private void DoCaptureEvent(SentryEvent @event)
+    private Coroutine DoCaptureEvent(SentryEvent @event)
     {
         if (Debug)
         {
             UnityDebug.Log("sending event to sentry.");
         }
 
-        StartCoroutine(ContinueSendingEvent(@event));
+        return StartCoroutine(ContinueSendingEvent(@event));
     }
 
     private void DoAddBreadcrumb(string message)


### PR DESCRIPTION
Changed the return value of the following methods from void to Coroutine.

````cs
public static void CaptureMessage(string message);
public static void CaptureEvent(SentryEvent @event);
private void DoCaptureMessage(string message);
private void DoCaptureEvent(SentryEvent @event);
````

By returning the executed ContinueSendingEvent as a Coroutine, the SDK user can process its state.

As an example, by modifying SentryTest.cs as follows, it can assure that a program running on a mobile platform will exit after the process of sending to Sentry is completed.
(Note that it uses [UniRx](https://github.com/neuecc/UniRx).)

```cs 
using UnityEngine.Assertions;
using UnityEngine;
using System;
using Sentry;
using UniRx;

public class SentryTest : MonoBehaviour {
    private int _counter = 0;

    private void Update() {
        _counter++;
        if (_counter % 100 == 0) // every 100 frames
        {
            SentrySdk.AddBreadcrumb("Frame number: " + _counter);
        }
    }

    private new void SendMessage(string message) {
        if (message == "exception") {
            throw new DivideByZeroException();
        } else if (message == "assert") {
            Assert.AreEqual(message, "not equal");
        } else if (message == "message") {
            QuitWithSentry("this is a message");
        } else if (message == "event") {
            var @event = new SentryEvent("Event message") {
                level = "debug"
            };

            SentrySdk.CaptureEvent(@event);
        }
    }

    private async void QuitWithSentry(string message) {
        await SentrySdk.CaptureMessage(message);
        Application.Quit();
    }
}
```
