### PR TITLE
Attachment to unity logger is made optional

### DIFF
--- a/Runtime/SentrySdk.cs
+++ b/Runtime/SentrySdk.cs
@@ -28,6 +28,9 @@ public class SentrySdk : MonoBehaviour
     [Header("Override game version")]
     public string Version = "";
 
+    [Header("Capture errors from unity default logger")]
+    public bool AttachToUnityLogger = true;
+
     private string _lastErrorMessage = "";
     private Dsn _dsn;
     private bool _initialized = false;
@@ -148,12 +151,18 @@ public class SentrySdk : MonoBehaviour
 
     public void OnEnable()
     {
-        Application.logMessageReceived += OnLogMessageReceived;
+        if (AttachToUnityLogger)
+        {
+            Application.logMessageReceived += OnLogMessageReceived;
+        }
     }
 
     public void OnDisable()
     {
-        Application.logMessageReceived -= OnLogMessageReceived;
+        if (AttachToUnityLogger)
+        {
+            Application.logMessageReceived -= OnLogMessageReceived;
+        }
     }
 
     public void OnGUI()

--- a/Runtime/SentrySdk.cs
+++ b/Runtime/SentrySdk.cs
@@ -28,14 +28,13 @@ public class SentrySdk : MonoBehaviour
     [Header("Override game version")]
     public string Version = "";
 
-    [Header("Capture errors from unity default logger")]
-    public bool AttachToUnityLogger = true;
-
     private string _lastErrorMessage = "";
     private Dsn _dsn;
     private bool _initialized = false;
 
     private static SentrySdk _instance = null;
+
+    private bool _isLogAttached;
 
     public void Start()
     {
@@ -149,20 +148,27 @@ public class SentrySdk : MonoBehaviour
             _noBreadcrumbs);
     }
 
-    public void OnEnable()
+    public void OnEnabled()
     {
-        if (AttachToUnityLogger)
-        {
-            Application.logMessageReceived += OnLogMessageReceived;
-        }
+        SetDefaultLogAttached(true);
     }
 
     public void OnDisable()
     {
-        if (AttachToUnityLogger)
+        SetDefaultLogAttached(false);
+    }
+
+    public void SetDefaultLogAttached(bool attached)
+    {
+        if (attached && !_isLogAttached)
+        {
+            Application.logMessageReceived += OnLogMessageReceived;
+        }
+        else if (!attached && _isLogAttached)
         {
             Application.logMessageReceived -= OnLogMessageReceived;
         }
+        _isLogAttached = attached;
     }
 
     public void OnGUI()


### PR DESCRIPTION
Added method to switch on/off attachment to unity logger in SentrySDK: SetDefaultLogAttached(bool attached).

We are sending events to sentry from our own logger handler (with some custom formatting). So we needed a way to disable events from default attachment.

I've tried to make this change as minimal as possible by adding a method to switch the default attachment off.

It would be great if you integrate those changes back or provide any other means to do the same.