### PR TITLE
Implemented event action to enable external modification of the SentryEvent

### DIFF
--- a/Runtime/Sentry.cs
+++ b/Runtime/Sentry.cs
@@ -357,11 +357,9 @@ namespace Sentry
         }
     }
 
-    // Unity doesn't serialize Dictionary
     [Serializable]
-    public class Tags
+    public class Tags : Dictionary<string, string>
     {
-        public string deviceUniqueIdentifier;
     }
 
     [Serializable]


### PR DESCRIPTION
Implemented event action to enable external modification of the SentryEvent before the event is sent.

An example usage is to add custom tags:
```
private void OnEnable() => SentrySdk.ModifySentryEvent += AddSentryTags;
private void OnDisable() => SentrySdk.ModifySentryEvent -= AddSentryTags;

private void AddSentryTags(SentryEvent sentryEvent)
{
      sentryEvent.tags.Add("tag1", "value1");
      sentryEvent.tags.Add("tag2", "value2");
      sentryEvent.tags.Add("tag3", "value3");
}
```